### PR TITLE
Added orochi oracle for multiTokenPaymaster Ancient8

### DIFF
--- a/admin_frontend/package-lock.json
+++ b/admin_frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin_frontend",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin_frontend",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "@emotion/react": "11.11.3",
         "@emotion/styled": "11.11.0",

--- a/admin_frontend/package.json
+++ b/admin_frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin_frontend",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "dependencies": {
     "@emotion/react": "11.11.3",

--- a/backend/config.json.default
+++ b/backend/config.json.default
@@ -214,5 +214,13 @@
             "etherspotPaymasterAddress": "0xB3AD9B9B06c6016f81404ee8FcCD0526F018Cf0C"
         },
         "thresholdValue": "21.8"
+    },
+    {
+        "chainId": 888888888,
+        "bundler": "https://ancient8-bundler.etherspot.io",
+        "contracts": {
+            "etherspotPaymasterAddress": "0x810FA4C915015b703db0878CF2B9344bEB254a40"
+        },
+        "thresholdValue": "0.016"
     }
 ]

--- a/backend/config.json.default
+++ b/backend/config.json.default
@@ -214,5 +214,13 @@
             "etherspotPaymasterAddress": "0xB3AD9B9B06c6016f81404ee8FcCD0526F018Cf0C"
         },
         "thresholdValue": "21.8"
+    },
+    {
+        "chainId": 888888888,
+        "bundler": "https://rpc.etherspot.io/ancient8?api-key=eyJvcmciOiI2NTIzZjY5MzUwOTBmNzAwMDFiYjJkZWIiLCJpZCI6ImUxN2VhZWQwZDViNDRjZWI5YjhlN2ZkZjc4YWI0OWRiIiwiaCI6Im11cm11cjEyOCJ9",
+        "contracts": {
+            "etherspotPaymasterAddress": "0x810FA4C915015b703db0878CF2B9344bEB254a40"
+        },
+        "thresholdValue": "0.016"
     }
 ]

--- a/backend/config.json.default
+++ b/backend/config.json.default
@@ -214,13 +214,5 @@
             "etherspotPaymasterAddress": "0xB3AD9B9B06c6016f81404ee8FcCD0526F018Cf0C"
         },
         "thresholdValue": "21.8"
-    },
-    {
-        "chainId": 888888888,
-        "bundler": "https://rpc.etherspot.io/ancient8?api-key=eyJvcmciOiI2NTIzZjY5MzUwOTBmNzAwMDFiYjJkZWIiLCJpZCI6ImUxN2VhZWQwZDViNDRjZWI5YjhlN2ZkZjc4YWI0OWRiIiwiaCI6Im11cm11cjEyOCJ9",
-        "contracts": {
-            "etherspotPaymasterAddress": "0x810FA4C915015b703db0878CF2B9344bEB254a40"
-        },
-        "thresholdValue": "0.016"
     }
 ]

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arka",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "ARKA - (Albanian for Cashier's case) is the first open source Paymaster as a service software",
   "type": "module",
   "directories": {
@@ -39,8 +39,9 @@
     "ethers": "5.7.2",
     "fastify": "4.24.3",
     "fastify-cron": "1.3.1",
+    "fastify-healthcheck": "4.4.0",
     "fastify-plugin": "3.0.1",
-    "getmac": "^6.6.0",
+    "getmac": "6.6.0",
     "graphql-request": "6.1.0",
     "node-fetch": "3.3.2",
     "sqlite": "5.1.1",

--- a/backend/src/abi/OrochiOracleAbi.ts
+++ b/backend/src/abi/OrochiOracleAbi.ts
@@ -1,0 +1,569 @@
+export default [
+  {
+      "inputs": [
+          {
+              "internalType": "address[]",
+              "name": "operatorList",
+              "type": "address[]"
+          }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "address",
+              "name": "user",
+              "type": "address"
+          }
+      ],
+      "name": "DeactivatedUser",
+      "type": "error"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "uint256",
+              "name": "length",
+              "type": "uint256"
+          }
+      ],
+      "name": "InvalidDataLength",
+      "type": "error"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+          }
+      ],
+      "name": "InvalidOperator",
+      "type": "error"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "uint256",
+              "name": "requiredLen",
+              "type": "uint256"
+          },
+          {
+              "internalType": "uint256",
+              "name": "maxLen",
+              "type": "uint256"
+          }
+      ],
+      "name": "OutOfRange",
+      "type": "error"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "bytes",
+              "name": "data",
+              "type": "bytes"
+          }
+      ],
+      "name": "UnableToPublishData",
+      "type": "error"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "uint64",
+              "name": "round",
+              "type": "uint64"
+          }
+      ],
+      "name": "UndefinedRound",
+      "type": "error"
+  },
+  {
+      "anonymous": false,
+      "inputs": [
+          {
+              "indexed": true,
+              "internalType": "address",
+              "name": "newOperator",
+              "type": "address"
+          }
+      ],
+      "name": "AddOperator",
+      "type": "event"
+  },
+  {
+      "anonymous": false,
+      "inputs": [
+          {
+              "indexed": true,
+              "internalType": "address",
+              "name": "actor",
+              "type": "address"
+          },
+          {
+              "indexed": true,
+              "internalType": "bool",
+              "name": "status",
+              "type": "bool"
+          }
+      ],
+      "name": "Deactivated",
+      "type": "event"
+  },
+  {
+      "anonymous": false,
+      "inputs": [
+          {
+              "indexed": true,
+              "internalType": "address",
+              "name": "actor",
+              "type": "address"
+          },
+          {
+              "indexed": true,
+              "internalType": "uint256",
+              "name": "identifier",
+              "type": "uint256"
+          },
+          {
+              "indexed": true,
+              "internalType": "bytes",
+              "name": "data",
+              "type": "bytes"
+          }
+      ],
+      "name": "FulFill",
+      "type": "event"
+  },
+  {
+      "anonymous": false,
+      "inputs": [
+          {
+              "indexed": true,
+              "internalType": "address",
+              "name": "previousOwner",
+              "type": "address"
+          },
+          {
+              "indexed": true,
+              "internalType": "address",
+              "name": "newOwner",
+              "type": "address"
+          }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+  },
+  {
+      "anonymous": false,
+      "inputs": [
+          {
+              "indexed": true,
+              "internalType": "uint32",
+              "name": "application",
+              "type": "uint32"
+          },
+          {
+              "indexed": true,
+              "internalType": "uint64",
+              "name": "round",
+              "type": "uint64"
+          },
+          {
+              "indexed": true,
+              "internalType": "bytes20",
+              "name": "identifier",
+              "type": "bytes20"
+          },
+          {
+              "indexed": false,
+              "internalType": "bytes32",
+              "name": "data",
+              "type": "bytes32"
+          }
+      ],
+      "name": "PublishData",
+      "type": "event"
+  },
+  {
+      "anonymous": false,
+      "inputs": [
+          {
+              "indexed": true,
+              "internalType": "address",
+              "name": "OldOperator",
+              "type": "address"
+          }
+      ],
+      "name": "RemoveOperator",
+      "type": "event"
+  },
+  {
+      "anonymous": false,
+      "inputs": [
+          {
+              "indexed": true,
+              "internalType": "address",
+              "name": "actor",
+              "type": "address"
+          },
+          {
+              "indexed": true,
+              "internalType": "uint256",
+              "name": "identifier",
+              "type": "uint256"
+          },
+          {
+              "indexed": true,
+              "internalType": "bytes",
+              "name": "data",
+              "type": "bytes"
+          }
+      ],
+      "name": "Request",
+      "type": "event"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "address",
+              "name": "newOperator",
+              "type": "address"
+          }
+      ],
+      "name": "addOperator",
+      "outputs": [
+          {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "uint256",
+              "name": "identifier",
+              "type": "uint256"
+          },
+          {
+              "internalType": "bytes",
+              "name": "data",
+              "type": "bytes"
+          }
+      ],
+      "name": "fulfill",
+      "outputs": [
+          {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "uint32",
+              "name": "appId",
+              "type": "uint32"
+          },
+          {
+              "internalType": "uint64",
+              "name": "round",
+              "type": "uint64"
+          },
+          {
+              "internalType": "bytes20",
+              "name": "identifier",
+              "type": "bytes20"
+          }
+      ],
+      "name": "getData",
+      "outputs": [
+          {
+              "internalType": "bytes32",
+              "name": "data",
+              "type": "bytes32"
+          }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "uint32",
+              "name": "appId",
+              "type": "uint32"
+          },
+          {
+              "internalType": "bytes20",
+              "name": "identifier",
+              "type": "bytes20"
+          }
+      ],
+      "name": "getLatestData",
+      "outputs": [
+          {
+              "internalType": "bytes32",
+              "name": "data",
+              "type": "bytes32"
+          }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "uint32",
+              "name": "appId",
+              "type": "uint32"
+          },
+          {
+              "internalType": "bytes20",
+              "name": "identifier",
+              "type": "bytes20"
+          }
+      ],
+      "name": "getLatestRound",
+      "outputs": [
+          {
+              "internalType": "uint64",
+              "name": "round",
+              "type": "uint64"
+          },
+          {
+              "internalType": "uint64",
+              "name": "lastUpdate",
+              "type": "uint64"
+          },
+          {
+              "internalType": "bytes32",
+              "name": "data",
+              "type": "bytes32"
+          }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "uint32",
+              "name": "appId",
+              "type": "uint32"
+          },
+          {
+              "internalType": "bytes20",
+              "name": "identifier",
+              "type": "bytes20"
+          }
+      ],
+      "name": "getMetadata",
+      "outputs": [
+          {
+              "internalType": "uint64",
+              "name": "round",
+              "type": "uint64"
+          },
+          {
+              "internalType": "uint64",
+              "name": "lastUpdate",
+              "type": "uint64"
+          }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "address",
+              "name": "user",
+              "type": "address"
+          }
+      ],
+      "name": "isDeactivated",
+      "outputs": [
+          {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "address",
+              "name": "checkAddress",
+              "type": "address"
+          }
+      ],
+      "name": "isOperator",
+      "outputs": [
+          {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+          {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+          }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "uint32",
+              "name": "appId",
+              "type": "uint32"
+          },
+          {
+              "internalType": "bytes",
+              "name": "packedData",
+              "type": "bytes"
+          }
+      ],
+      "name": "publishData",
+      "outputs": [
+          {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "bytes",
+              "name": "packedData",
+              "type": "bytes"
+          }
+      ],
+      "name": "publishPrice",
+      "outputs": [
+          {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "address",
+              "name": "oldOperator",
+              "type": "address"
+          }
+      ],
+      "name": "removeOperator",
+      "outputs": [
+          {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+  },
+  {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "uint256",
+              "name": "identifier",
+              "type": "uint256"
+          },
+          {
+              "internalType": "bytes",
+              "name": "data",
+              "type": "bytes"
+          }
+      ],
+      "name": "request",
+      "outputs": [
+          {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "address",
+              "name": "userAddress",
+              "type": "address"
+          },
+          {
+              "internalType": "bool",
+              "name": "status",
+              "type": "bool"
+          }
+      ],
+      "name": "setDeactivatedStatus",
+      "outputs": [
+          {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+  },
+  {
+      "inputs": [
+          {
+              "internalType": "address",
+              "name": "newOwner",
+              "type": "address"
+          }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+  }
+] as const;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -38,13 +38,6 @@ const routes: FastifyPluginAsync = async (server) => {
     }
   }
 
-  server.get(
-    "/healthcheck",
-    async function (request, reply) {
-      return reply.code(ReturnCode.SUCCESS).send('Arka Service Running...');
-    }
-  )
-
   server.post(
     "/",
     async function (request, reply) {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import fastify, { FastifyInstance } from 'fastify';
+import fastifyHealthcheck from 'fastify-healthcheck';
 import cors from '@fastify/cors';
 import fastifyCron from 'fastify-cron';
 import { providers, ethers } from 'ethers';
@@ -39,6 +40,11 @@ const initializeServer = async (): Promise<void> => {
     // put your options here
     preflightContinue: true
   })
+
+  await server.register(fastifyHealthcheck, {
+    healthcheckUrl: "/healthcheck",
+    logLevel: "warn"
+  });
 
   await server.register(routes);
 
@@ -198,8 +204,10 @@ const initializeServer = async (): Promise<void> => {
             customPaymasters = {...customPaymasters, ...multiTokenPaymasters};
             for (const chainId in customPaymasters) {
               const networkConfig = getNetworkConfig(chainId, '');
-              for (const symbol in customPaymasters[chainId]) {
-                checkDeposit(customPaymasters[chainId][symbol], networkConfig.bundler, process.env.WEBHOOK_URL, networkConfig.thresholdValue ?? '0.001', Number(chainId), server.log)
+              if (networkConfig) {
+                for (const symbol in customPaymasters[chainId]) {
+                  checkDeposit(customPaymasters[chainId][symbol], networkConfig.bundler, process.env.WEBHOOK_URL, networkConfig.thresholdValue ?? '0.001', Number(chainId), server.log)
+                }
               }
             }
           }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arka_frontend",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arka_frontend",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "7.21.11",
         "@emotion/react": "^11.11.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arka_frontend",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "7.21.11",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in details -->
- MULTI_TOKEN_ORACLES var will now contain orochi oracle address
- Added orochi Abu and methods to get native token price and used that as an external exchange rate for the multiToken Paymaster
- Added healthCheck module and passed the LOG_LEVEL as warn to hide the info logs when called for better logging and error checking through logs

## Types of changes
What types of changes does your code introduce?
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Further comments (optional)
<!--- Additional comments, don't hesitate :) -->
- Tested locally with ancient8 Mainnet multiTokenPaymaster deployment https://scan.ancient8.gg/tx/0x55b5bc8f491321cfb5a5abb912e198b90ecba98df76322a543552ef5b170e97b
