### PR TITLE
ft: change data type change for chainid

### DIFF
--- a/backend/migrations/20241126170930-change-chain-id-to-bigint.cjs
+++ b/backend/migrations/20241126170930-change-chain-id-to-bigint.cjs
@@ -1,0 +1,45 @@
+require('dotenv').config();
+const { DataTypes } = require('sequelize');
+
+async function up({ context: queryInterface }) {
+    await queryInterface.changeColumn(
+        {schema: process.env.DATABASE_SCHEMA_NAME, tableName: 'sponsorship_policies'},
+        'ENABLED_CHAINS',
+        {
+            type: DataTypes.ARRAY(DataTypes.BIGINT),
+            allowNull: true
+        }
+    );
+
+    await queryInterface.changeColumn(
+        {schema: process.env.DATABASE_SCHEMA_NAME, tableName: 'contract_whitelist'},
+        'CHAIN_ID',
+        {
+            type: DataTypes.BIGINT,
+            allowNull: false
+        }
+    );
+}
+
+async function down({ context: queryInterface }) {
+    await queryInterface.changeColumn(
+        {schema: process.env.DATABASE_SCHEMA_NAME, tableName: 'sponsorship_policies'},
+        'ENABLED_CHAINS',
+        {
+            type: DataTypes.ARRAY(DataTypes.INTEGER),
+            allowNull: true
+        }
+    );
+
+    await queryInterface.changeColumn(
+        {schema: process.env.DATABASE_SCHEMA_NAME, tableName: 'contract_whitelist'},
+        'CHAIN_ID',
+        {
+            type: DataTypes.INTEGER,
+            allowNull: false
+        }
+    );
+}
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {up, down};

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arka",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "ARKA - (Albanian for Cashier's case) is the first open source Paymaster as a service software",
   "type": "module",
   "directories": {

--- a/backend/src/models/contract-whitelist.ts
+++ b/backend/src/models/contract-whitelist.ts
@@ -42,7 +42,11 @@ export function initializeContractWhitelistModel(sequelize: Sequelize, schema: s
     chainId: {
       type: DataTypes.BIGINT,
       allowNull: false,
-      field: 'CHAIN_ID'
+      field: 'CHAIN_ID',
+      get() {
+        const value = this.getDataValue('chainId');
+        return +value;
+      }
     },
     createdAt: {
       type: DataTypes.DATE,

--- a/backend/src/models/contract-whitelist.ts
+++ b/backend/src/models/contract-whitelist.ts
@@ -40,7 +40,7 @@ export function initializeContractWhitelistModel(sequelize: Sequelize, schema: s
       field: 'ABI'
     },
     chainId: {
-      type: DataTypes.INTEGER,
+      type: DataTypes.BIGINT,
       allowNull: false,
       field: 'CHAIN_ID'
     },

--- a/backend/src/models/sponsorship-policy.ts
+++ b/backend/src/models/sponsorship-policy.ts
@@ -114,7 +114,11 @@ export function initializeSponsorshipPolicyModel(sequelize: Sequelize, schema: s
         enabledChains: {
             type: DataTypes.ARRAY(DataTypes.BIGINT),
             allowNull: true,
-            field: 'ENABLED_CHAINS'
+            field: 'ENABLED_CHAINS',
+            get() {
+                const value = this.getDataValue('enabledChains');
+                return value?.map((item: any) => +item);
+            }
         },
         supportedEPVersions: {
             type: DataTypes.ARRAY(DataTypes.STRING),

--- a/backend/src/models/sponsorship-policy.ts
+++ b/backend/src/models/sponsorship-policy.ts
@@ -112,7 +112,7 @@ export function initializeSponsorshipPolicyModel(sequelize: Sequelize, schema: s
             field: 'IS_APPLICABLE_TO_ALL_NETWORKS'
         },
         enabledChains: {
-            type: DataTypes.ARRAY(DataTypes.INTEGER),
+            type: DataTypes.ARRAY(DataTypes.BIGINT),
             allowNull: true,
             field: 'ENABLED_CHAINS'
         },

--- a/backend/src/repository/sponsorship-policy-repository.ts
+++ b/backend/src/repository/sponsorship-policy-repository.ts
@@ -39,7 +39,7 @@ export class SponsorshipPolicyRepository {
                 ]
             }
         });
-        return result.map(apiKey => apiKey as SponsorshipPolicy);
+        return result.map(apiKey => apiKey.get() as SponsorshipPolicy);
     }
 
     // findAllEnabled

--- a/backend/src/routes/admin-routes.ts
+++ b/backend/src/routes/admin-routes.ts
@@ -107,14 +107,8 @@ const adminRoutes: FastifyPluginAsync = async (server) => {
       const privateKey = wallet.privateKey;
       const publicAddress = await wallet.getAddress();
 
-      request.log.info(`-----------headers---------- ${JSON.stringify(request.headers)}`);
-      request.log.info(`-----------hmac secret---------- ${server.config.HMAC_SECRET}`);
-      
-
       if(!unsafeMode) {
         const { 'x-signature': signature, 'x-timestamp': timestamp } = request.headers as IncomingHttpHeaders & AuthDto;
-        request.log.info(`-----------signature---------- ${signature}`);
-        request.log.info(`-----------timestamp---------- ${timestamp}`);
         
         if(!signature || !timestamp)
           return reply.code(ReturnCode.NOT_AUTHORIZED).send({ error: ErrorMessage.INVALID_SIGNATURE_OR_TIMESTAMP });

--- a/backend/src/utils/crypto.ts
+++ b/backend/src/utils/crypto.ts
@@ -66,8 +66,6 @@ export async function decodeSafe(value: string, hmacSecret: string) {
 export function verifySignature(signature: string, data: string, timestamp: string, hmacSecret: string) {
   // unauthorize signature if signed before 10s or signed in future.
   const now = Date.now();
-  server.log.info(`-----------now---------- ${now}`);
-  server.log.info(`-----------hmacSecret---------- ${hmacSecret}`);
   if(
     now < parseInt(timestamp) ||
     now - parseInt(timestamp) > 10000
@@ -75,7 +73,5 @@ export function verifySignature(signature: string, data: string, timestamp: stri
     return false;
   }
   const computedSignature = createDigest(data + timestamp, 'hex', hmacSecret);
-  server.log.info(`-----------computedSignature----------${computedSignature}`);
-  server.log.info(`-----------signature----------${signature} ${computedSignature === signature}`);
   return signature === computedSignature;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in details -->
- changing the chain id type from 32 bit to 64 bit. This is done in order to store mekong chain id(7078815900) which currently overflows for a 32 bit integer and unable to store on tables (sponsorship_policies and contract_whitelist)

## Types of changes
What types of changes does your code introduce?
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe): 

## Further comments (optional)
<!--- Additional comments, don't hesitate :) -->
- unsure if this breaks the code anywhere else, as sequelize no longer returns the chain id as number it instead returns as a string because it is a 64 bit value.
- i have tested all the sponsorship policy api and contract whitelist apis, with this change we store the chain ids as bigints but get the values as integers (type number is TS) so that there should not be any breaking changes.
- sharing the postman collection of the tested apis.
[2844.postman_collection.json](https://github.com/user-attachments/files/17963256/2844.postman_collection.json)

