### PR TITLE
Update GitHub Actions checkout from v3 to v4

### DIFF
--- a/.github/workflows/check-package-version.yml
+++ b/.github/workflows/check-package-version.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup NodeJS
         uses: "actions/setup-node@v3"


### PR DESCRIPTION
This PR updates the GitHub Actions checkout action from version 3 to version 4 in the package version check workflow.

Changes:
- Updated `actions/checkout@v3` to `actions/checkout@v4` in check-package-version.yml

This update ensures we're using the latest stable version of the checkout action, which includes performance improvements and bug fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the GitHub Actions workflow to use the latest version of the checkout action for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->